### PR TITLE
TemplateDoesNotExist Error

### DIFF
--- a/appmate/core/settings.py
+++ b/appmate/core/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'app',
     'rest_framework',
+    'django_filters',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
just a few minutes ago i clone this project and run with a clean venv environment

# behavior
`TemplateDoesNotExist` error raised on table view (e.g. `api/sample/`)

# environment
```bash
$ pip -V
pip 9.0.1 from /usr/home/tzing/appmate/env/lib/python3.6/site-packages (python 3.6)

$ pip freeze
click==6.7
Django==1.10.6
django-crispy-forms==1.6.1
django-filter==1.0.2
django-suit==0.2.24
djangorestframework==3.6.2
gdbm==0.0.0
Jinja2==2.9.5
Markdown==2.6.8
MarkupSafe==1.0
olefile==0.44
Pillow==4.0.0
pytoml==0.1.11
pytz==2016.10
PyYAML==3.12
sqlite3==0.0.0
Tkinter==0.0.0
yasha==2.1
```

# note
it is sure that commit f1487eb8672eeb139220316f92f8eb2acacde996 dose not induce this error